### PR TITLE
generic element and Vector type.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SPGBox"
 uuid = "bf97046b-3e66-4aa0-9aed-26efb7fac769"
 authors = ["Leandro Martinez <leandro@iqm.unicamp.br>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/SPGBoxResult.jl
+++ b/src/SPGBoxResult.jl
@@ -19,10 +19,10 @@ optimization method.
          2. Maximum number of function evaluations achieved.
 
 """ 
-struct SPGBoxResult
-  x::Vector{Float64}
-  f::Float64
-  gnorm::Float64
+struct SPGBoxResult{T,X}
+  x::X
+  f::T
+  gnorm::T
   nit::Int64
   nfeval::Int64
   ierr::Int64 

--- a/src/VAux.jl
+++ b/src/VAux.jl
@@ -1,15 +1,17 @@
 #
 # Structure to store auxiliary arrays
 #
-struct VAux
-  g :: Vector{Float64}
-  xn :: Vector{Float64}
-  gn :: Vector{Float64}
-  fprev :: Vector{Float64}
+struct VAux{T}
+  g :: Vector{T}
+  xn :: Vector{T}
+  gn :: Vector{T}
+  fprev :: Vector{T}
 end
-VAux(n,m) = VAux( Vector{Float64}(undef,n), 
-                  Vector{Float64}(undef,n), 
-                  Vector{Float64}(undef,n), 
-                  Vector{Float64}(undef,m) )
+VAux(n,m) = VAux(Float64,n,m)
+
+VAux(::Type{T},n,m) where T = VAux( zeros(T,n), #BigFloat needs to be allocated first
+                                    zeros(T,n),
+                                    zeros(T,n),
+                                    zeros(T,m))
 # The default value for m
 VAux(n) = VAux(n,10)

--- a/src/spgbox_main.jl
+++ b/src/spgbox_main.jl
@@ -80,7 +80,7 @@ function spgbox!(
   nitmax::Int = 100,
   nfevalmax::Int = 1000,
   m::Int = 10,
-  vaux::VAux = VAux(length(x),m),
+  vaux::VAux = VAux(eltype(x),length(x),m),
   iprint::Int = 0,
   project_x0::Bool = true
 ) 
@@ -205,6 +205,7 @@ function spgbox!(
       xn .= x .- t .* g
       !isnothing(upper) && (xn .= min.(xn,upper))
       !isnothing(lower) && (xn .= max.(xn,lower))
+      
       if iprint > 2
         println(" xn = ", xn[begin], " ... ", xn[end])
       end

--- a/src/spgbox_main.jl
+++ b/src/spgbox_main.jl
@@ -202,9 +202,15 @@ function spgbox!(
 
     fn = +Inf
     while( fn > fref )
-      xn .= x .- t .* g
-      !isnothing(upper) && (xn .= min.(xn,upper))
-      !isnothing(lower) && (xn .= max.(xn,lower))
+      for i in eachindex(x)
+        xn[i] = x[i] - t*g[i]
+        if !isnothing(upper)
+          xn[i] = min(xn[i],upper[i])
+        end
+        if !isnothing(lower)
+          xn[i] = max(xn[i],lower[i])
+        end
+      end
       
       if iprint > 2
         println(" xn = ", xn[begin], " ... ", xn[end])

--- a/src/spgbox_main.jl
+++ b/src/spgbox_main.jl
@@ -229,7 +229,7 @@ function spgbox!(
       num = num + (xn[i]-x[i])^2
       den = den + (xn[i]-x[i])*(gn[i]-g[i])
     end
-    if den <= 0.
+    if den <= zero(T)
       tspg = T(100)
     else
       tspg =  min(T(1.e3),num/den)

--- a/src/spgbox_main.jl
+++ b/src/spgbox_main.jl
@@ -73,10 +73,10 @@ julia> spgbox!(f,g!,x,lower=[2.,-Inf])
 function spgbox!(
   f::Function,
   g!::Function,
-  lower::Union{Nothing,AbstractVector{Float64}}, 
-  upper::Union{Nothing,AbstractVector{Float64}}, 
-  x::AbstractVector{Float64};
-  eps::Float64 = 1.e-5,
+  lower::Union{Nothing,AbstractVector{<:Real}}, 
+  upper::Union{Nothing,AbstractVector{<:Real}}, 
+  x::AbstractVector{<:Real};
+  eps = 1.e-5,
   nitmax::Int = 100,
   nfevalmax::Int = 1000,
   m::Int = 10,
@@ -96,18 +96,21 @@ end
 function spgbox!(
   f::Function,
   g!::Function,
-  x::AbstractVector{Float64};
-  lower::Union{Nothing,AbstractVector{Float64}} = nothing, 
-  upper::Union{Nothing,AbstractVector{Float64}} = nothing, 
-  eps::Float64 = 1.e-5,
+  x::AbstractVector{<:Real};
+  lower::Union{Nothing,AbstractVector{<:Real}} = nothing, 
+  upper::Union{Nothing,AbstractVector{<:Real}} = nothing, 
+  eps = 1.e-5,
   nitmax::Int = 100,
   nfevalmax::Int = 1000,
   m::Int = 10,
-  vaux::VAux = VAux(length(x),m),
+  vaux::VAux = VAux(eltype(x),length(x),m),
   iprint::Int = 0,
   project_x0::Bool = true
 )
+  #variable type
+  T = eltype(x) 
 
+  eps = T(eps)
   # Number of variables
   n = length(x)
 
@@ -153,7 +156,7 @@ function spgbox!(
   g!(g,x)
   gnorm = pr_gradnorm(g,x,lower,upper)
 
-  tspg = 1.
+  tspg = one(T)
   for i in eachindex(fprev)
     fprev[i] = fcurrent
   end
@@ -199,15 +202,9 @@ function spgbox!(
 
     fn = +Inf
     while( fn > fref )
-      for i in eachindex(x)
-        xn[i] = x[i] - t*g[i]
-        if !isnothing(upper)
-          xn[i] = min(xn[i],upper[i])
-        end
-        if !isnothing(lower)
-          xn[i] = max(xn[i],lower[i])
-        end
-      end 
+      xn .= x .- t .* g
+      !isnothing(upper) && (xn .= min.(xn,upper))
+      !isnothing(lower) && (xn .= max.(xn,lower))
       if iprint > 2
         println(" xn = ", xn[begin], " ... ", xn[end])
       end
@@ -226,16 +223,16 @@ function spgbox!(
     end
 
     g!(gn,xn)
-    num = 0.
-    den = 0.
+    num = zero(T)
+    den = zero(T)
     for i in eachindex(x)
       num = num + (xn[i]-x[i])^2
       den = den + (xn[i]-x[i])*(gn[i]-g[i])
     end
     if den <= 0.
-      tspg = 100.
+      tspg = T(100)
     else
-      tspg =  min(1.e3,num/den)
+      tspg =  min(T(1.e3),num/den)
     end
     fcurrent = fn
     for i in eachindex(x)
@@ -276,14 +273,14 @@ Returns a structure of type `SPGBoxResult`, containing the best solution found i
 function spgbox(
   f::Function,
   g!::Function,
-  lower::Union{Nothing,AbstractVector{Float64}}, 
-  upper::Union{Nothing,AbstractVector{Float64}}, 
-  x::AbstractVector{Float64};
-  eps::Float64 = 1.e-5,
+  lower::Union{Nothing,AbstractVector{<:Real}}, 
+  upper::Union{Nothing,AbstractVector{<:Real}}, 
+  x::AbstractVector{<:Real};
+  eps = 1.e-5,
   nitmax::Int = 100,
   nfevalmax::Int = 1000,
   m::Int = 10,
-  vaux::VAux = VAux(length(x),m),
+  vaux::VAux = VAux(eltype(x),length(x),m),
   iprint::Int = 0,
   project_x0::Bool = true
 ) 
@@ -300,14 +297,14 @@ end
 function spgbox(
   f::Function,
   g!::Function,
-  x::AbstractVector{Float64};
-  lower::Union{Nothing,AbstractVector{Float64}} = nothing, 
-  upper::Union{Nothing,AbstractVector{Float64}} = nothing, 
-  eps::Float64 = 1.e-5,
+  x::AbstractVector{<:Real};
+  lower::Union{Nothing,AbstractVector{<:Real}} = nothing, 
+  upper::Union{Nothing,AbstractVector{<:Real}} = nothing, 
+  eps = 1.e-5,
   nitmax::Int = 100,
   nfevalmax::Int = 1000,
   m::Int = 10,
-  vaux::VAux = VAux(length(x),m),
+  vaux::VAux = VAux(eltype(x),length(x),m),
   iprint::Int = 0,
   project_x0::Bool = true
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,11 @@ using SPGBox
 
 @testset "simple polynomial" begin
 
-  f(x) = x[1]^2 + (x[2]-1.)^2
+  f(x) = x[1]^2 + (x[2]-1)^2
   
   function g!(g,x) 
     g[1] = 2*x[1]
-    g[2] = 2*(x[2]-1.)
+    g[2] = 2*(x[2]-1)
   end
   
   x = [ 10. , 18. ]
@@ -69,6 +69,19 @@ using SPGBox
   @test R.f ≈ 0.
   @test R.x ≈ [0.,1.]
   
+  #BigFloat support
+  x = BigFloat[ 10. , 18. ]
+  R = spgbox!(f,g!,x)
+  @test R.f ≈ 0.
+  @test R.x ≈ [0.,1.]
+  @test eltype(R.f) == eltype(R.x) == BigFloat
+
+    #Float32 support
+    x = Float32[ 10. , 18. ]
+    R = spgbox!(f,g!,x)
+    @test R.f ≈ 0.
+    @test R.x ≈ [0.,1.]
+    @test eltype(R.f) == eltype(R.x) == Float32
 end
 
 


### PR DESCRIPTION
this PR allows to use more generic types for input. for example:

```julia
using StaticArrays, SPGBox

julia> f(x) = x[1]^2 + x[2]^2

julia> function g!(x,g)
         g[1] = 2*x[1]
         g[2] = 2*x[2]
       end
       
xbig = BigFloat.(2 .+ rand(2))
xstatic = MVector{2,Float64}(xbig )
lower = [2.,-Inf]
lowerbig = big.(lower)

resbig = spgbox!(f,g!,xbig,lower=lowerbig)
resstatic = spgbox!(f,g!,xstatic,lower=lower) #same number type, there is no conversion between different vectors.
```
